### PR TITLE
Should have the ability to display error page without redirecting users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ to flush the template cache.  Afterwards, you must go to the UtilityPage in the
 CMS and select the manually select the template from the dropdown to tell
 SilverStripe which template to use to render the page for display.
 
+### Redirecting vs. Displaying at any URL
+
+By default, the current functionality is to redirect users to a separate URL which you can configure within the CMS (e.g. `/offline/`), however it may be useful for you to simply display the maintenance message at any URL that the user may visit (to ensure user does not lose the page that they're currently at, in case maintenance window is very short). 
+
+To disable redirects, drop the following lines into your site's `config.yaml` file:
+
+```yaml
+UtilityPage:
+  DisableRedirect: true
+```
+
+
 
 Known Issues
 ------------

--- a/code/MaintenanceModeExtension.php
+++ b/code/MaintenanceModeExtension.php
@@ -47,7 +47,7 @@ class MaintenanceMode_Page_ControllerExtension extends Extension {
 
         // Process the request internally to ensure the URL is maintained (instead of redirecting to our maintenance page's URL).
         $controller = ModelAsController::controller_for($utilityPage);
-        $response = $controller->handleRequest($this->owner->getRequest());
+        $response = $controller->handleRequest(new SS_HTTPRequest("GET", "/"));
         throw new SS_HTTPResponse_Exception($response, $response->getStatusCode());
     }
 

--- a/code/MaintenanceModeExtension.php
+++ b/code/MaintenanceModeExtension.php
@@ -6,10 +6,18 @@
  * Page if maintenance mode is switched on.
  *
  * @author Darren-Lee Joseph <darrenleejoseph@gmail.com>
+ * @author Patrick Nelson <pat@catchyour.com>
  * @package maintenancemode
  */
 class MaintenanceMode_Page_ControllerExtension extends Extension {
 
+    // Set to true after the first execution as an extra measure to prevent infinite recursion, just in case.
+    protected static $runOnce = false;
+
+    /**
+     * @throws SS_HTTPResponse_Exception
+     * @return SS_HTTPResponse
+     */
     public function onBeforeInit() {
 
         if(Permission::check("ADMIN")) return;
@@ -17,11 +25,30 @@ class MaintenanceMode_Page_ControllerExtension extends Extension {
         $config = SiteConfig::current_site_config();
         if(!$config->MaintenanceMode) return;
 
-        //If this is not the utility page, do a temporary (302) redirect to it
-        if($this->owner->dataRecord->ClassName != "UtilityPage") {
-            return $this->owner->redirect(UtilityPage::get()->first()->AbsoluteLink(), 302);
+        // Fetch our utility page instance now.
+        /** @var Page $utilityPage */
+        $utilityPage = UtilityPage::get()->first();
+        if (!$utilityPage) return; // We need a utility page before we can do anything.
+
+        // See if we're still configured to redirect...
+        if (!$utilityPage->config()->DisableRedirect) {
+            //If this is not the utility page, do a temporary (302) redirect to it
+            if($this->owner->dataRecord->ClassName != "UtilityPage") {
+                return $this->owner->redirect($utilityPage->AbsoluteLink(), 302);
+            }
         }
 
+        // No need to execute more than once.
+        if ($this->owner instanceof UtilityPage_Controller) return;
+
+        // Additional failsafe, just in case (for some reason) the current controller isn't descended from UtilityPage_Controller.
+        if (static::$runOnce) return;
+        static::$runOnce = true;
+
+        // Process the request internally to ensure the URL is maintained (instead of redirecting to our maintenance page's URL).
+        $controller = ModelAsController::controller_for($utilityPage);
+        $response = $controller->handleRequest($this->owner->getRequest());
+        throw new SS_HTTPResponse_Exception($response, $response->getStatusCode());
     }
 
 }//end class MaintenanceMode_Page_ControllerExtension


### PR DESCRIPTION
I noticed that when we enabled maintenance mode, this module would redirect users to a new page URL (the URL of the `UtilityPage` instance in the database). In many cases this may be fine, but in my case I'd prefer the ability to display this page regardless of the URL without redirecting them. This is easily accomplished in a few lines of code.

For progressive enhancement, and because the current functionality is to perform the redirect, I've setup a new configuration option:

``` yaml
UtilityPage:
  DisableRedirect: true
```

This allows you to display the maintenance page on any current URL instead of redirecting to `/offline/` (for example). I also added some basic documentation covering this new functionality, which you can preview here:

https://github.com/patricknelson/silverstripe-maintenance-mode
