### PR TITLE
Added the ability to allow IP addreses pass the maintenance page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SilverStripe Maintenance Mode Module
-Maintainance/Offline Mode Module for SilverStripe.  Allows an 
-administrator to put site in offline mode with 503 status to display a 
-'Coming Soon', 'Under Construction' or 'Down for Maintenance' Page to 
-regular visitors, whilst allowing a logged in admin user to browse and 
+Maintainance/Offline Mode Module for SilverStripe.  Allows an
+administrator to put site in offline mode with 503 status to display a
+'Coming Soon', 'Under Construction' or 'Down for Maintenance' Page to
+regular visitors, whilst allowing a logged in admin user to browse and
 make changes to the site.
 
 
@@ -29,7 +29,7 @@ Installation can be done either by composer or by manually downloading a release
 
  1.  Download the module from [the releases page](https://github.com/thisisbd/silverstripe-maintenance-mode/releases).
  2.  Extract the file (if you are on windows try 7-zip for extracting tar.gz files
- 3.  Make sure the folder after being extracted is named 'maintenance-mode' 
+ 3.  Make sure the folder after being extracted is named 'maintenance-mode'
  4.  Place this directory in your sites root directory. This is the one with framework and cms in it.
  5. Visit `<yoursite.com>/dev/build/?flush` to rebuild the database.
 
@@ -44,8 +44,8 @@ theme template SilverStripe uses to render the page for display.
 
 
 ### Templating
-To override the default UtilityPage template, add a template called 
-UtilityPage.ss in the templates folder of your theme (above Layouts) and then 
+To override the default UtilityPage template, add a template called
+UtilityPage.ss in the templates folder of your theme (above Layouts) and then
 flush the template cache.
 
 If you wish to use a different template for the UtilityPage, there are no
@@ -57,7 +57,7 @@ SilverStripe which template to use to render the page for display.
 
 ### Redirecting vs. Displaying at any URL
 
-By default, the current functionality is to redirect users to a separate URL which you can configure within the CMS (e.g. `/offline/`), however it may be useful for you to simply display the maintenance message at any URL that the user may visit (to ensure user does not lose the page that they're currently at, in case maintenance window is very short). 
+By default, the current functionality is to redirect users to a separate URL which you can configure within the CMS (e.g. `/offline/`), however it may be useful for you to simply display the maintenance message at any URL that the user may visit (to ensure user does not lose the page that they're currently at, in case maintenance window is very short).
 
 To disable redirects, drop the following lines into your site's `config.yaml` file:
 
@@ -66,7 +66,16 @@ UtilityPage:
   DisableRedirect: true
 ```
 
+### Allowing specific IP addresses
+You can configure the module to also allow specific IP addresses pass the maintenance page.
+To add IP's add the following lines into your site's `config.yaml` file:
 
+```yaml
+Page_Controller:
+  allowed_ips:
+    - '127.0.0.1'
+    - '::1'
+```
 
 Known Issues
 ------------


### PR DESCRIPTION
I've added in the ability to have an array of allowed IP addresses.
They can be configured using YML, I have added instructions into the README file.

There are a couple new functions, one gets the IP based on a few $_SERVER checks and then another that checks if the current IP is in the array off allowed IP's.

This has been a common requirement when using this module as sometimes being logged in as someone other than full admin was necessary for testing or deployment.
