### PR TITLE
NEW feature: Adding task to enable/disable maintenance mode via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ UtilityPage:
   DisableRedirect: true
 ```
 
+### Command Line
+
+You can toggle maintenance mode either `on` or `off` via the command line easily by simply running the `MaintenanceMode` task. For example:
+
+```bash
+# Via Sake:
+sake dev/tasks/MaintenanceMode on
+
+# Via the CLI script directly:
+php framework/cli-script.php dev/tasks/MaintenanceMode on
+```
+
+
 ### Allowing specific IP addresses
 You can configure the module to also allow specific IP addresses pass the maintenance page.
 To add IP's add the following lines into your site's `config.yaml` file:

--- a/code/MaintenanceMode.php
+++ b/code/MaintenanceMode.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Ability to easily toggle maintenance mode via CLI. To run this command:
+ *
+ * 		sake dev/tasks/MaintenanceMode [on|off]
+ *
+ * @author Patrick Nelson <pat@catchyour.com>
+ * @package maintenancemode
+ * @since 2015-10-08
+ */
+
+class MaintenanceMode extends BuildTask {
+	protected $title = 'Maintance Mode Task';
+	protected $description = 'Ability to easily toggle maintenance mode via CLI.';
+	protected $enabled = true;
+
+	/**
+	 * @param	SS_HTTPRequest $request
+	 */
+	public function run($request) {
+		// Only allow execution from the command line (for simplicity).
+		if (!Director::is_cli()) {
+			echo "<p>Sorry, but this can only be run from the command line.</p>";
+			return;
+		}
+
+		try  {
+			// Get and validate desired maintenance mode setting.
+			$get = $request->getVars();
+			if (empty($get["args"])) throw new Exception("Please provide an argument (e.g. 'on' or 'off').", 1);
+			$arg = strtolower(current($get["args"]));
+			if ($arg != "on" && $arg != "off") throw new Exception("Invalid argument: '$arg' (expected 'on' or 'off')", 2);
+
+			// Get and write site configuration now.
+			$config = SiteConfig::current_site_config();
+			$previous = (!empty($config->MaintenanceMode) ? "on" : "off");
+			$config->MaintenanceMode = ($arg == "on");
+			$config->write();
+
+			// Output status and exit.
+			if ($arg != $previous) {
+				$this->output("Maintenance mode is now '$arg'.");
+			} else {
+				$this->output("NOTE: Maintenance mode was already '$arg' (nothing has changed).");
+			}
+
+
+		} catch(Exception $e) {
+			$this->output("ERROR: " . $e->getMessage());
+			if ($e->getCode() <= 2) $this->output("Usage:  sake dev/tasks/MaintenanceMode [on|off]");
+		}
+	}
+
+	####################
+	## HELPER METHODS ##
+	####################
+
+	/**
+	 * Output helper.
+	 *
+	 * @param $text
+	 */
+	protected function output($text) {
+		echo "$text\n";
+	}
+}


### PR DESCRIPTION
I setup a task many months ago and realized it was pretty simple and well isolated so I figured I'd set this up as a PR and let you give it a look. Since I use capistrano to deploy to production, I needed a command line method (via SSH) to take the website down and put it into maintenance mode. Check this out, syntax is simple:

``` bash
# Via Sake:
sake dev/tasks/MaintenanceMode on

# Via the CLI script directly:
php framework/cli-script.php dev/tasks/MaintenanceMode on
```

See here for example documentation: https://github.com/patricknelson/silverstripe-maintenance-mode/tree/feature-cli-task
