### PR TITLE
FIX for #15 Ensuring we use the framework for determining client IP (security/bug fix)

### DIFF
--- a/code/MaintenanceModeExtension.php
+++ b/code/MaintenanceModeExtension.php
@@ -84,22 +84,7 @@ class MaintenanceMode_Page_ControllerExtension extends Extension {
 	 * @return string
 	 */
 	public function getClientIP() {
-		if (isset($_SERVER['HTTP_CLIENT_IP'])) {
-			$ipaddress = $_SERVER['HTTP_CLIENT_IP'];
-		} elseif (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-			$ipaddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
-		} elseif (isset($_SERVER['HTTP_X_FORWARDED'])) {
-			$ipaddress = $_SERVER['HTTP_X_FORWARDED'];
-		} elseif (isset($_SERVER['HTTP_FORWARDED_FOR'])) {
-			$ipaddress = $_SERVER['HTTP_FORWARDED_FOR'];
-		} elseif (isset($_SERVER['HTTP_FORWARDED'])) {
-			$ipaddress = $_SERVER['HTTP_FORWARDED'];
-		} elseif (isset($_SERVER['REMOTE_ADDR'])) {
-			$ipaddress = $_SERVER['REMOTE_ADDR'];
-		} else {
-			$ipaddress = 'Unknown';
-		}
-		return $ipaddress;
+		return $this->owner->getRequest()->getIP();
 	}
 
 }//end class MaintenanceMode_Page_ControllerExtension


### PR DESCRIPTION
Addresses #15. Just for security purposes, use a centralized and authenticated method for retrieving/trusting client IP's.
