### PR TITLE
Update packagist name and convert to vendormodule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "dljoseph/silverstripe-maintenance-mode",
+    "name": "thisisbd/silverstripe-maintenance-mode",
     "description": "SilverStripe Maintenance Mode Module.  Allows an administrator to put site in offline mode with 503 status to display a 'Coming Soon', 'Under Construction' or 'Down for Maintenance' Page to regular visitors, whilst allowing a logged in admin user to browse and make changes to the site.",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "homepage": "http://github.com/dljoseph/silverstripe-maintenance-mode",
     "keywords": [
         "silverstripe","maintenance mode","under construction","coming soon",


### PR DESCRIPTION
The packagist name for this repository seems to have changed. If you google "silverstripe maintenance mode" and click on the addons page, it points at the following URLs along with this repository:
Addons:
    https://addons.silverstripe.org/add-ons/thisisbd/silverstripe-maintenance-mode
Homepage:
    http://github.com/dljoseph/silverstripe-maintenance-mode 
Packagist:
    https://packagist.org/packages/thisisbd/silverstripe-maintenance-mode
Repository:
    https://github.com/dljoseph/silverstripe-maintenance-mode

Changing the package name allows the module to be installed via composer. Changing it to vendormodule allows it to be installed in the vendors folder (see issue #31 )